### PR TITLE
Add newline before table.

### DIFF
--- a/mdgen/core/table.py
+++ b/mdgen/core/table.py
@@ -6,7 +6,7 @@ class MarkdownTableGenerator:
     """ This will create markdown tables using a list of lists. """
 
     def new_table(self, list_items_list: list):
-        output = ''
+        output = '\n '
         for index, list_item in enumerate(list_items_list):
             output += (
                 f"{MARKDOWN_TABLE_COL_SEPARATOR}"


### PR DESCRIPTION
While using this repo with Python-Markdown sometimes, tables would not generate properly and just leave them in paragraph.
Solution to it, is just to add newline character before every table which solved issue for me.